### PR TITLE
newUrl -> modifyUrl

### DIFF
--- a/frontend/Main.elm
+++ b/frontend/Main.elm
@@ -95,7 +95,7 @@ update msg model =
             User userId ->
               if Just userId == Maybe.map .id model.profile.user
               then
-                { model | route = Profile } ! [ Navigation.newUrl (routeToPath Profile) ]
+                { model | route = Profile } ! [ Navigation.modifyUrl (routeToPath Profile) ]
               else
                 (modelWithRoute, Cmd.batch [ User.getUser userId, User.getAds userId ] |> Cmd.map UserMessage)
 


### PR DESCRIPTION
If user accesses their own profile by id (for example /tradenomit/2 or from a link elsewhere) back button wont work, because redirect with Navigation.newUrl from tradenomit/2 to /profiili adds both urls to history. Using Navigation.modifyUrl doesn't add new url to history, and back button works again. 