### PR TITLE
Add http2 support to nginx

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -28,8 +28,8 @@ http {
     }
 
     server {
-        listen    443 ssl;
-        listen [::]:443 ssl;
+        listen    443 ssl http2;
+        listen [::]:443 ssl http2;
 
         ssl                  on;
         ssl_certificate      ssl/{{server_name}}.pem;


### PR DESCRIPTION
Falls back to http1.1 if not supported by the browser. 

Note: Works best if used with OpenSSL 1.0.2 or newer - older OpenSSL might cause some users to fallback to http1.1 - still safe to use. 'nginx -V' shows the OpenSSL version being used.