### PR TITLE
Update pm2 ansible role and persist list of apps

### DIFF
--- a/conf/pm2install.yml
+++ b/conf/pm2install.yml
@@ -12,4 +12,6 @@
       - run: /srv/app.json
         path: /srv/checkout/tradenomiitti
         cmd: start
+    pm2_post_cmds:
+      - run: save
     pm2_user: ubuntu

--- a/conf/preinstall.sh
+++ b/conf/preinstall.sh
@@ -10,5 +10,5 @@ then
   done
 fi
 
-ansible-galaxy install weareinteractive.pm2 --roles-path conf/roles
-ansible-galaxy install nickjj.letsencrypt --roles-path conf/roles
+ansible-galaxy install weareinteractive.pm2,2.4.0 --force --roles-path conf/roles
+ansible-galaxy install nickjj.letsencrypt,v0.2.2 --force --roles-path conf/roles


### PR DESCRIPTION
Without this the node server does not start automatically after host server reboot. The role only has this feature in the latest version, so need to rerun `npm run preansible` to get it.